### PR TITLE
Key Generation fixed for numerical attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,15 @@ node_modules/
 cpabe-0.11/
 libbswabe-0.9/
 pbc-0.5.14/
+gmp-6.1.2/
 build/
 pub_key
 master_key
 priv_key
 *.node
 *.cpabe
-*.tar.gz
+*.tar.gz*
+*.tar.lz*
 *.log
+
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             apt-get -y -q install autoconf;
             apt-get -y -q install automake;
             apt-get -y -q install libtool;
+            apt-get -y -q install valgrind;
+            sudo npm install -g node-gyp
             "   
         end
 
@@ -75,7 +77,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         ncpabe.vm.provision "build_module", type: :shell do |shell|
            shell.inline = "
            cd /vagrant;
-           sudo npm install -g node-gyp
            node-gyp configure;
            node-gyp build;
            " 
@@ -84,7 +85,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         ncpabe.vm.provision "test_build", type: :shell do |shell|
             shell.inline = "
             cd /vagrant
-            cp build/Release/cp-abe.node jssrc/;
+            cp build/Release/cpabe.node jssrc/;
             npm install;
             npm test;
             "

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,94 @@
+VAGRANTFILE_API_VERSION = "2"
+DEFAULT_BOX = "ubuntu/trusty64"
+
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+    config.vm.define("NodeCPABE") do |ncpabe|
+        ncpabe.vm.box = DEFAULT_BOX
+        ncpabe.vm.provider "virtualbox" do |v|
+            v.name = "NodeCPABE"
+            v.customize ["modifyvm", :id, "--memory", 512]
+        end
+
+        ncpabe.vm.provision "update", type: :shell do |shell|
+            shell.inline = "apt-get -y -q update"
+        end
+
+        ncpabe.vm.provision "install_htop", type: :shell do |shell|
+            shell.inline = "apt-get -y -q install htop"
+        end
+
+        ncpabe.vm.provision "install_node", type: :shell do |shell|
+            shell.inline = "
+            cd ~;
+            wget --no-check-certificate https://nodejs.org/dist/v7.2.0/node-v7.2.0-linux-x64.tar.gz;
+            cd /usr/local;
+            tar --strip-components 1 -xzf ~/node-v7.2.0-linux-x64.tar.gz;
+            sudo npm install -g n;
+            sudo n stable;
+            sudo npm install npm@latest -g
+            "
+        end
+        
+        #ncpabe.vm.provision "install_express-generator", type: :shell do |shell|
+        #    shell.inline = "sudo npm install -g express-generator"
+        #end
+
+        ncpabe.vm.provision "test_npm_installation", type: :shell do |shell|
+            shell.inline = "
+            node -v;
+            npm version;
+            npm list -g;
+            "
+        end
+
+        ncpabe.vm.provision "install_dependencies", type: :shell do |shell|
+            shell.inline = "
+            apt-get -y -q install build-essential;
+            apt-get -y -q install wget;
+            apt-get -y -q install m4;
+            apt-get -y -q install flex bison;
+            apt-get -y -q install libssl-dev;
+            apt-get -y -q install gtk+-2.0;
+            apt-get -y -q install libgmp-dev
+            apt-get -y -q install lzip;
+            apt-get -y -q install autoconf;
+            apt-get -y -q install automake;
+            apt-get -y -q install libtool;
+            "   
+        end
+
+        ncpabe.vm.provision "install_gmp", type: :shell do |shell|
+            shell.inline = "
+            wget https://gmplib.org/download/gmp/gmp-6.1.2.tar.lz;
+            tar --lzip -xvf gmp-6.1.2.tar.lz;
+            cd gmp-6.1.2;
+            ./configure;
+            make;
+            make check;
+            sudo make install;
+            "
+        end
+
+        ncpabe.vm.provision "build_module", type: :shell do |shell|
+           shell.inline = "
+           cd /vagrant;
+           sudo npm install -g node-gyp
+           node-gyp configure;
+           node-gyp build;
+           " 
+        end
+
+        ncpabe.vm.provision "test_build", type: :shell do |shell|
+            shell.inline = "
+            cd /vagrant
+            cp build/Release/cp-abe.node jssrc/;
+            npm install;
+            npm test;
+            "
+        end
+    end
+    
+end

--- a/jssrc/test/cpabe.js
+++ b/jssrc/test/cpabe.js
@@ -2,13 +2,13 @@ const cpabe = require('../../cpabe');
 const chai = require('chai');
 const expect = chai.expect;
 
-describe('CP-ABE functionality', function() {
-  it('CP-ABE setup should exist', function() {
+describe('CP-ABE functionality', function () {
+  it('CP-ABE setup should exist', function () {
     expect(cpabe.setup).to.exists;
     expect(cpabe.encryptMessage).to.exists;
   });
 
-  it('CP-ABE encrypt function must get three arguments', function() {
+  it('CP-ABE encrypt function must get three arguments', function () {
     expect(() => {
       cpabe.encryptMessage();
     }).to.throw;
@@ -21,15 +21,15 @@ describe('CP-ABE functionality', function() {
   })
 
   var keys_for_multiple_times = cpabe.setup();
-  it('CP-ABE encrypt function multiple times', function() {
-      cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
-      cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
-      cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
-      cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
-      cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
+  it('CP-ABE encrypt function multiple times', function () {
+    cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
+    cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
+    cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
+    cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
+    cpabe.encryptMessage(keys_for_multiple_times.pubkey, "usuario or level = 4", new Buffer("hola"));
   })
 
-  it('CP-ABE encrypt function must process only valid policies', function() {
+  it('CP-ABE encrypt function must process only valid policies', function () {
     expect(() => {
       cpabe.encryptMessage(new Buffer("a"), "policy level = 2", new Buffer("a"))
     }).to.throw;
@@ -37,9 +37,71 @@ describe('CP-ABE functionality', function() {
     expect(() => {
       cpabe.encryptMessage(new Buffer("a"), "policy and level = 2", new Buffer("a"))
     }).not.to.throw;
+
+    expect(() => {
+      cpabe.encryptMessage(new Buffer("a"), "policy level = 266#3", new Buffer("a"))
+    }).to.throw;
   })
 
-  it('CP-ABE encryption and decryption should work', function() {
+  it('CP-ABE generate numerical keys', function () {
+    var keys = cpabe.setup();
+    var message = "hello world " + Math.random();
+    var encrypted = cpabe.encryptMessage(keys.pubkey, "admin or policytest", new Buffer(message));
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["x = 30"]);
+    }).not.to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["y = 30#6"]);
+    }).not.to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["y = 14#7"]);
+    }).not.to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["y = 340#65"]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["y = 16#3"]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["z = "]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, [" = 69"]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, [" = "]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["a = 'b'"]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["c = d"]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["e = 21#"]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["f = #45"]);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["y = 16#3"]);
+    }).to.throw;
+  })
+
+  it('CP-ABE encryption and decryption should work', function () {
     var keys = cpabe.setup();
     var message = "hello world " + Math.random();
     var encrypted = cpabe.encryptMessage(keys.pubkey, "admin or policytest", new Buffer(message));
@@ -48,7 +110,7 @@ describe('CP-ABE functionality', function() {
     expect(decrypted.toString()).to.be.equal(message);
   })
 
-  it('CP-ABE encryption with complex policies', function() {
+  it('CP-ABE encryption with complex policies', function () {
     var keys = cpabe.setup();
     var message = "hello world " + Math.random();
     var encrypted = cpabe.encryptMessage(keys.pubkey, "admin or user and helloaccess", new Buffer(message));
@@ -57,7 +119,19 @@ describe('CP-ABE functionality', function() {
     var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
     expect(decrypted.toString()).to.be.equal(message);
 
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["admin", "user"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["admin", "helloaccess"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
     privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["user", "helloaccess"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["admin", "user", "helloaccess"]);
     var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
     expect(decrypted.toString()).to.be.equal(message);
 
@@ -71,4 +145,199 @@ describe('CP-ABE functionality', function() {
       cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
     }).to.throw;
   })
+
+  it('CP-ABE encryption with grouped policies', function () {
+    var keys = cpabe.setup();
+    var message = "hello world " + Math.random();
+    var encrypted = cpabe.encryptMessage(keys.pubkey, "(admin | user) & helloaccess", new Buffer(message));
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["shabu", "admin"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["user"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["helloaccess"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["admin", "user"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["admin", "helloaccess"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["user", "helloaccess"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["admin", "user", "helloaccess"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+  })
+
+  it('CP-ABE encryption with threshold gates', function () {
+    var keys = cpabe.setup();
+    var message = "hello world " + Math.random();
+    var encrypted = cpabe.encryptMessage(keys.pubkey, "2 of (a,b,c)", new Buffer(message));
+
+    expect(() => {
+      privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["a"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["b"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["c"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["a", "b"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["a", "c"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["b", "c"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["a", "b", "c"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+  })
+
+  it('CP-ABE decryption with whole number attributes (equality)', function () {
+    var keys = cpabe.setup();
+    var message = "hello world " + Math.random();
+
+    var encrypted = cpabe.encryptMessage(keys.pubkey, "exec_level = 15", new Buffer(message));
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 15"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 12"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 17"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+  })
+
+  it('CP-ABE decryption with whole number attributes (strict inequality)', function () {
+    var keys = cpabe.setup();
+    var message = "hello world " + Math.random();
+
+    var encrypted = cpabe.encryptMessage(keys.pubkey, "exec_level > 6", new Buffer(message));
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 7"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 6"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 5"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+  })
+
+  it('CP-ABE decryption with whole number attributes (inequality)', function () {
+    var keys = cpabe.setup();
+    var message = "hello world " + Math.random();
+
+    var encrypted = cpabe.encryptMessage(keys.pubkey, "exec_level <= 10", new Buffer(message));
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 8"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 10"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 12"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+  })
+
+  it('CP-ABE decryption with explicit-length numbers', function () {
+    var keys = cpabe.setup();
+    var message = "hello world " + Math.random();
+    var encrypted = cpabe.encryptMessage(keys.pubkey, "exec_level >= 5#4", new Buffer(message));
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 5#4"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 8#4"]);
+    var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 3#4"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw;
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 8#5"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw
+
+    expect(() => {
+      var privkey = cpabe.keygen(keys.pubkey, keys.mstkey, ["exec_level = 8#3"]);
+      var decrypted = cpabe.decryptMessage(keys.pubkey, privkey, encrypted);
+    }).to.throw
+
+  })
+
+  it('CP-ABE encryption and decryption using example from paper', function () {
+    var keys = cpabe.setup();
+    var message = "security_report.pdf " + Math.random();
+
+    var policy = "(sysadmin and (hire_date < 946702800 or security_team)) or (business_staff and 2 of (executive_level >= 5, audit_group, strategy_team))"
+
+    var hire_date = new Date(parseInt(Date.now() / 1000)).getSeconds()
+    var hire_date_attr = "hire_date = " + hire_date;
+
+    var encrypted = cpabe.encryptMessage(keys.pubkey, policy, new Buffer(message));
+
+    var sara_priv_key = cpabe.keygen(keys.pubkey, keys.mstkey, ["sysadmin", "it_department", "office = 1431", hire_date_attr]);
+    var kevin_priv_key = cpabe.keygen(keys.pubkey, keys.mstkey, ["business_staff", "strategy_team", "executive_level = 7", "office = 2362", hire_date_attr]);
+
+    expect(() => {
+      var decrypted = cpabe.decryptMessage(keys.pubkey, sara_priv_key, encrypted);
+    }).to.throw;
+
+    var decrypted = cpabe.decryptMessage(keys.pubkey, kevin_priv_key, encrypted);
+    expect(decrypted.toString()).to.be.equal(message);
+
+  })
+
 });

--- a/jssrc/test/paper_example.js
+++ b/jssrc/test/paper_example.js
@@ -1,0 +1,28 @@
+const cpabe = require('../../cpabe');
+
+var keys = cpabe.setup();
+var message = "security_report.pdf " + Math.random();
+
+console.log("message: " + message);
+
+var policy = "(sysadmin and (hire_date < 946702800 or security_team)) or (business_staff and 2 of (executive_level >= 5, audit_group, strategy_team))"
+
+var hire_date = parseInt(Math.floor(Date.now() / 1000));
+var hire_date_attr = "hire_date = " + hire_date;
+console.log(hire_date_attr);
+console.log(hire_date < 946702800);
+
+var encrypted = cpabe.encryptMessage(keys.pubkey, policy, new Buffer(message));
+
+var sara_priv_key = cpabe.keygen(keys.pubkey, keys.mstkey, ["sysadmin", "it_department", "office = 1431", hire_date_attr]);
+var kevin_priv_key = cpabe.keygen(keys.pubkey, keys.mstkey, ["business_staff", "strategy_team", "executive_level = 7", "office = 2362", hire_date_attr]);
+
+// Will decrypt
+var decrypted = cpabe.decryptMessage(keys.pubkey, kevin_priv_key, encrypted);
+console.log("decrypted: " + decrypted.toString());
+
+// Will not decrypt
+var decrypted = cpabe.decryptMessage(keys.pubkey, sara_priv_key, encrypted);
+console.log("decrypted: " + decrypted.toString());
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,711 @@
+{
+  "name": "node-cp-abe",
+  "version": "0.0.4",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "aproba": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+    },
+    "brace-expansion": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+      "optional": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+    },
+    "mocha": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "dev": true
+    },
+    "node-gyp": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz",
+      "integrity": "sha1-GVYQZ/8YVGSt7UeCEmgfR/1XjLw="
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
+    },
+    "npmlog": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA=="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+    },
+    "readable-stream": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g="
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+    },
+    "safe-buffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+    },
+    "sshpk": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+    },
+    "verror": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/patches/cpabe-0.11@policy_lang.c.patch
+++ b/patches/cpabe-0.11@policy_lang.c.patch
@@ -1,0 +1,4 @@
+2225c2225
+< 		*l = g_slist_append(*l, g_strdup(a));
+---
+> 		*l = g_slist_append(*l, a);

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -37,6 +37,7 @@ patch -R cpabe-0.11/common.c patches/cpabe-0.11@common.c.patch
 patch -R cpabe-0.11/common.h patches/cpabe-0.11@common.h.patch
 patch -R cpabe-0.11/policy_lang.y patches/cpabe-0.11@policy_lang.y.patch
 patch -R libbswabe-0.9/Makefile.in patches/libbswabe-0.9@Makefile.in.patch
+patch -R cpabe-0.11/policy_lang.c patches/cpabe-0.11@policy_lang.c.patch
 
 # Configure and compile
 


### PR DESCRIPTION
1. Added a vagrant test environment
2. Added logic on processing numerical attributes which uses cpabe's parsing function from polict_lang.c
3. Patched cpabe since some attributes coming from the wrapper will turn as garbage strings
4. Added more test cases
5. Added script to demonstrate the example of Bethencourt, et. al.

One of the test cases fail. I think it's because of the known performance issue of CP-ABE since it does a lot of computations.